### PR TITLE
Changed simpleMDE to easyMDE to allow easier mobile usage, as well as…

### DIFF
--- a/tgrsite/templates/tgrsite/addnavbar.html
+++ b/tgrsite/templates/tgrsite/addnavbar.html
@@ -221,5 +221,5 @@ This defines the navbar and the extra scripts.
                 );
             });
         });
-    </script>0
+    </script>
 {% endblock %}

--- a/tgrsite/templates/tgrsite/addnavbar.html
+++ b/tgrsite/templates/tgrsite/addnavbar.html
@@ -29,12 +29,13 @@ This defines the navbar and the extra scripts.
         });
     </script>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
-    <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
-
     {% comment font icons library %}{% endcomment %}
     <link type="text/css" rel="stylesheet"
           href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
+    <link rel="stylesheet" href="https://unpkg.com/easymde/dist/easymde.min.css">
+    <script src="https://unpkg.com/easymde/dist/easymde.min.js"></script>
+
 
     <!-- For the footer: -->
     <style>

--- a/tgrsite/templates/tgrsite/addnavbar.html
+++ b/tgrsite/templates/tgrsite/addnavbar.html
@@ -213,7 +213,7 @@ This defines the navbar and the extra scripts.
             $(".markdown-input").each(function (i, e) {
                 console.log("Element " + e);
                 window.simplemde.push(
-                    new SimpleMDE({
+                    new EasyMDE({
                         element: e,
                         placeholder: "Write Markdown (or just regular text) here...",
                         forceSync: true,
@@ -221,5 +221,5 @@ This defines the navbar and the extra scripts.
                 );
             });
         });
-    </script>
+    </script>0
 {% endblock %}


### PR DESCRIPTION
… fix several bugs.
This is not an ideal peice of software either, but it is better than simpleMDE. It still suffers from the sticky caps keyboard, the lack of auto-correct and some other weird quirks, but it allows you to navigate through the text, which is an improvement on simpleMDE. I have looked at several other options and they all seem to have fairly fundamental flaws as well. Most of the fully featured editors that actually work at all either require a node workspace (sorry, not happening), or are implemented using full screen iframes, which is incredibly clunky. 
In the future I hope the rewrite of codemirror will fix many of these issues and allow functional md editors to appear.